### PR TITLE
Changes to github workflow and to container tests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,8 +5,7 @@ on:
     branches: [main]
   # Also trigger on release created event
   release:
-    types:
-      - created
+    types: [published]
 
 jobs:
   build:
@@ -42,6 +41,8 @@ jobs:
           docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "gpg --version"
           docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "gpg-agent --version"
           docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "unzip"
+          docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "inspec exec /home/default/profiles/cms-ars-3.1-moderate-aws-foundations-cis-overlay --chef-license accept-silent" # this test verifies that the inspec binary has all the dependencies it needs
+          docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "exit 1"
       - name: Push docker image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [cht-github-workflow-fixes]
+    branches: [main]
   # Also trigger on release created event
   release:
     types: [published]
@@ -42,7 +42,6 @@ jobs:
           docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "gpg-agent --version"
           docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "unzip"
           docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "inspec exec /home/default/profiles/cms-ars-3.1-moderate-aws-foundations-cis-overlay --chef-license accept-silent" # this test verifies that the inspec binary has all the dependencies it needs
-          docker run --entrypoint /bin/bash $ECR_REGISTRY/$ECR_REPOSITORY:${TAG} -c "exit 1"
       - name: Push docker image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: docker-build
 
 on:
   push:
-    branches: [main]
+    branches: [cht-github-workflow-fixes]
   # Also trigger on release created event
   release:
     types: [published]


### PR DESCRIPTION
- Changes the docker-build condition for releases to happen upon publishing instead of creation
  - This was done in response to a bug RD and I encountered when trying to deploy a new release to address a issue with chef/inspec:stable missing a key dependency for inspec.
- Adds a test in the docker-build to verify that inspec has all the dependencies it needs to run